### PR TITLE
Change aos.js script tag async attribution to defer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1626,7 +1626,7 @@
     </div>
   </div>
 
-  <script async src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js" defer></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"


### PR DESCRIPTION
Hello,

script.js depends on aos.js and aos.js is loaded with the async attribution.

* index.html
....
` <script async src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>`
.....
` <script src="scripts.js" defer></script>`

* First line of script.js
`AOS.init({ duration: 600, anchorPlacement: "center-bottom" });`

 
Depending on the order in which the scripts are loadeed,
the following error may sometimes occur and nothing may be displayed when the index.html is loaded. 

``Uncaught ReferenceError: AOS is not defined
    at scripts.js:1:1``

Could I change "async" attribution to "defer" attribution?
Deferred scripts keep their relative order.

`<script src="https://unpkg.com/aos@2.3.1/dist/aos.js" defer></script>`
